### PR TITLE
Create bridge directory and env example

### DIFF
--- a/bridge/.env.example
+++ b/bridge/.env.example
@@ -1,0 +1,16 @@
+# Slack (Socket Mode — no public URL)
+SLACK_APP_TOKEN=xapp-xxxxxxxxxxxxxxxx
+SLACK_BOT_TOKEN=xoxb-xxxxxxxxxxxxxxxx
+
+# Google Calendar OAuth (Desktop)
+GOOGLE_CLIENT_ID=xxxxxxxxxxxx-xxxxxxxxxxxxxxxxxxxxxxxx.apps.googleusercontent.com
+GOOGLE_CLIENT_SECRET=ignored_or_value_from_console
+OAUTH_REDIRECT=http://127.0.0.1:3535/oauth2/callback
+
+# Twilio (SMS)
+TWILIO_ACCOUNT_SID=ACxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+TWILIO_AUTH_TOKEN=xxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+# Either a number or a Messaging Service SID
+TWILIO_FROM_NUMBER=+1xxxxxxxxxx
+# TWILIO_MESSAGING_SERVICE_SID=MGxxxxxxxxxxxxxxxxxxxxx
+


### PR DESCRIPTION
Add `bridge/.env.example` to provide example configurations for Slack, Google Calendar, and Twilio integrations.

---
<a href="https://cursor.com/background-agent?bcId=bc-da346d5b-be7e-4fbf-b5e8-eca2b47163ae">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-da346d5b-be7e-4fbf-b5e8-eca2b47163ae">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

